### PR TITLE
Filter footprint

### DIFF
--- a/src/internal-components/filtering/InlineFilterContainer.tsx
+++ b/src/internal-components/filtering/InlineFilterContainer.tsx
@@ -40,11 +40,13 @@ export const InlineFilterContainer: React.FunctionComponent<InlineFilterContaine
                 onChange={value => props.onFilterChange({...filterDefinition, value})}
                 filterType={filterDefinition.filterType}
             />
-            <FilterTypeDropdownButton selectedFilterType={filterDefinition.filterType} filterTypes={filterTypes} onChange={newFilterType => props.onFilterChange({...filterDefinition, filterType: newFilterType, operator: FilterTypeOperatorCodes[newFilterType]})}>
-                <div className={`filter-button ${props.isActive ? "filter-button-active" : ""}`}>
-                    <i className={`${'filter-button-content'} fas fa-filter`} />
-                </div>
-            </FilterTypeDropdownButton>
+            {(filterTypes && filterTypes.length > 1) &&
+                <FilterTypeDropdownButton selectedFilterType={filterDefinition.filterType} filterTypes={filterTypes} onChange={newFilterType => props.onFilterChange({...filterDefinition, filterType: newFilterType, operator: FilterTypeOperatorCodes[newFilterType]})}>
+                    <div className={`filter-button ${props.isActive ? "filter-button-active" : ""}`}>
+                        <i className={`${'filter-button-content'} fas fa-filter`} />
+                    </div>
+                </FilterTypeDropdownButton>
+            }
         </>
     )
 };

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -19,7 +19,7 @@
 .fancy-grid-column-filter-container {
     display: flex;
     height: 45px;
-    padding: 0 25px 0 25px;
+    padding: 0 15px;
     align-items: center;
     text-align: center;
 
@@ -254,7 +254,7 @@
 
 .filter-button {
     display: inline-block;
-    padding: 10px;
+    padding: 10px 0 10px 10px;
     cursor: pointer;
     font-family:'FontAwesome'!important;
     position: relative;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -125,6 +125,7 @@
 
 .fancy-grid-column-header-text {
     flex: 1;
+    margin: 0 10px;
 
     &:focus-within {
         color: #4285c3;


### PR DESCRIPTION
Reduce padding on sides of filter inputs and hide the filter icon for inline filteres if there is only one filter type. Add some padding to the sides of the column titles